### PR TITLE
Remove duplicates from table

### DIFF
--- a/include/blocklist.pf/buffer.h
+++ b/include/blocklist.pf/buffer.h
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <string.h>
 #include <blocklist.pf/string.h>
+#include <search.h>
 
 #define MAXROWS 100000
 #define MAXCOLS 1000
@@ -14,6 +15,6 @@ typedef struct {
 } buffer;
 
 buffer* new_buffer(FILE *f, int maxl, int maxw);
-buffer* filter_buffer(buffer *buf);
+buffer* filter_buffer(buffer *buf, struct hsearch_data *tbl);
 char* format_buffer(buffer *buf, int per_line);
 void free_buffer(buffer *buf);

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -2,6 +2,7 @@
 #include <blocklist.pf/file.h>
 #include <blocklist.pf/buffer.h>
 #include <blocklist.pf/cmd.h>
+#include <search.h>
 
 void
 fetch_cmd(void) {
@@ -27,17 +28,20 @@ cat_cmd(void) {
   int size;
   char *str;
   buffer *buf;
+  struct hsearch_data tbl;
   size = sizeof(BLOCKLISTS) / sizeof(BLOCKLISTS[0]);
+  hcreate_r(0, &tbl);
   printf("table <blocklist> {\n");
   for (int i = 0; i < size; i++) {
     blocklist bl = BLOCKLISTS[i];
     printf("##\n# %s\n# %s\n# %s\n", bl.name, bl.desc, bl.url);
     buf = read_file(bl.path, MAXROWS, MAXCOLS);
-    buf = filter_buffer(buf);
+    buf = filter_buffer(buf, &tbl);
     str = format_buffer(buf, 3);
     printf("%s", str);
     free_buffer(buf);
     free(str);
   }
   printf("}\n");
+  hdestroy_r(&tbl);
 }


### PR DESCRIPTION
By using the hash table provided by search.h.

This solution is slower, but prevents duplicates from 
being entered into the table. And as a result, reduces 
the memory required by pf when loading the table into 
memory.

Number of lines (3 addresses per line):

* Before: 18954
* After : 15602

That's (roughly) 10,000 less IP addresses.