### PR TITLE
Replace strcat with mempcpy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ build: $(BIN_FILE)
 clean:
 	rm -rf $(BIN_DIR)
 
+cat: build
+	$(BIN_FILE) cat
+
 $(BIN_FILE):
 	mkdir -p $(BIN_DIR)
 	$(CC) $(CFLAGS) $(SRC_FILES) -I$(INC_DIR) -o $@ $^

--- a/src/string.c
+++ b/src/string.c
@@ -1,6 +1,7 @@
 #include <string.h>
 
-char* chomp(char *str) {
+char*
+chomp(char *str) {
   for(int i = strlen(str); i > 0; i--) {
     if(str[i] == '\n') {
       str[i] = '\0';


### PR DESCRIPTION
This change also happens to improve performance by a lot. 
The `blocklist.net.ua` blocklist contains over 100k entries, and 
before this change would take around 9 seconds to process. 
After this change, it takes around a second to process.