### PR TITLE
Allow data directory path to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,6 @@ file. The project is written in C, still young, one of my few C
 projects, and for now only works on platforms where libfetch is
 available (eg FreeBSD).
 
-## Tables
-
-The following tables are made available:
-
-* __attacks__ <br>
-  A table of IP addresses reported to be associated with attacks (eg brute force attacks).
-* __malware__ <br>
-  A table of IP addresses reported to be associated with malware.
-* __reputation__ <br>
-  A table of IP addresses reported to be associated with suspicous or malicious activity.
-* __anonymizers__ <br>
-  A table of IP addresses reported to be associated with anonymity (eg Tor).
-* __adware__ <br>
-  A table of IP addreses reported to be associated with adware.
-
 ## Examples
 
 The command line interface:
@@ -44,6 +29,30 @@ An example of how the tables might be used from `/etc/pf.conf`:
     block out quick on ue0 from any to $blocklists
     pass out on ue0
     pass in on ue0
+
+## Tables
+
+The following tables are made available:
+
+* __attacks__ <br>
+  A table of IP addresses reported to be associated with attacks (eg brute force attacks).
+* __malware__ <br>
+  A table of IP addresses reported to be associated with malware.
+* __reputation__ <br>
+  A table of IP addresses reported to be associated with suspicous or malicious activity.
+* __anonymizers__ <br>
+  A table of IP addresses reported to be associated with anonymity (eg Tor).
+* __adware__ <br>
+  A table of IP addreses reported to be associated with adware.
+
+## Configuration
+
+In order of preference, the blocklists that are fetched can be saved to:
+
+* `$BLOCKLISTPF_DIR`
+* Otherwise: `$XDG_DATA_HOME/blocklist.pf/`
+* Otherwise: `$HOME/.local/share/blocklist.pf`
+* Otherwise: `usr/local/share/blocklist.pf`
 
 ## Install
 

--- a/include/blocklist.pf/blocklist.h
+++ b/include/blocklist.pf/blocklist.h
@@ -15,4 +15,4 @@ typedef struct {
 
 extern const char* TABLES[5];
 extern blocklist BLOCKLISTS[11];
-htable* group_blocklists_by_category(blocklist blocklist[], size_t size);
+htable* group_blocklists(blocklist blocklist[], size_t size);

--- a/include/blocklist.pf/blocklist.h
+++ b/include/blocklist.pf/blocklist.h
@@ -8,7 +8,7 @@ typedef struct {
   const char *desc;
   const char *table;
   const char *url;
-  const char *path;
+  const char *filename;
   const char *format;
 } blocklist;
 

--- a/include/blocklist.pf/path.h
+++ b/include/blocklist.pf/path.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+#include <errno.h>
+#include <sys/stat.h>
+
+char* blocklistpf_dir(void);
+char* join_path(char *str, ...);
+int mkdir_p(char *path);

--- a/src/blocklists.c
+++ b/src/blocklists.c
@@ -14,7 +14,7 @@ blocklist BLOCKLISTS[] = {
     .name = "blocklist.de",
     .desc = "A list of IP addresses recommended for block by blocklist.de",
     .table = "attacks",
-    .path = "/usr/local/share/pf/blocklists/blocklist.txt",
+    .filename = "attacks_blocklist.de.txt",
     .url = "https://lists.blocklist.de/lists/all.txt",
     .format = "ipset"
   },
@@ -22,7 +22,7 @@ blocklist BLOCKLISTS[] = {
     .name = "emergingthreats.net",
     .desc = "A list of IP addresses recommended for block by Emerging Threats",
     .table = "attacks",
-    .path = "/usr/local/share/pf/blocklists/emergingthreats_compromised_ips.txt",
+    .filename = "attacks_etcompromised.txt",
     .url = "https://iplists.firehol.org/files/et_compromised.ipset",
     .format = "ipset"
   },
@@ -30,7 +30,7 @@ blocklist BLOCKLISTS[] = {
     .name = "emergingthreats.net",
     .desc = "A list of IP addresses recommended for block by Emerging Threats",
     .table = "attacks",
-    .path = "/usr/local/share/pf/blocklists/emergingthreats_block_ips.txt",
+    .filename = "attacks_etblock.txt",
     .url = "https://iplists.firehol.org/files/et_block.netset",
     .format = "ipset"
   },
@@ -38,7 +38,7 @@ blocklist BLOCKLISTS[] = {
     .name = "firehol (level 1)",
     .desc = "A list of IP addresses recommended for block by firehol",
     .table = "attacks",
-    .path = "/usr/local/share/pf/blocklists/firehol_level1.txt",
+    .filename = "attacks_firehol1.txt",
     .url = "https://iplists.firehol.org/files/firehol_level1.netset",
     .format = "ipset"
   },
@@ -46,7 +46,7 @@ blocklist BLOCKLISTS[] = {
     .name = "firehol (level 2)",
     .desc = "A list of IP addresses recommended for block by firehol",
     .table = "attacks",
-    .path = "/usr/local/share/pf/blocklists/firehol_level2.txt",
+    .filename = "attacks_firehol2.txt",
     .url = "https://iplists.firehol.org/files/firehol_level2.netset",
     .format = "ipset"
   },
@@ -54,7 +54,7 @@ blocklist BLOCKLISTS[] = {
     .name = "firehol (webserver)",
     .desc = "A list of IP addresses recommended for block by firehol",
     .table = "attacks",
-    .path = "/usr/local/share/pf/blocklists/firehol_webserver.txt",
+    .filename = "attacks_fireholwebserver.txt",
     .url = "https://iplists.firehol.org/files/firehol_webserver.netset",
     .format = "ipset"
   },
@@ -62,7 +62,7 @@ blocklist BLOCKLISTS[] = {
     .name = "blocklist.net.ua",
     .desc = "A list of IP addresses recommended for block by blocklist.net.ua",
     .table = "attacks",
-    .path = "/usr/local/share/pf/blocklists/blocklist.net.ua.txt",
+    .filename = "attacks_blocklist.net.ua.txt",
     .url = "https://iplists.firehol.org/files/blocklist_net_ua.ipset",
     .format = "ipset"
   },
@@ -73,7 +73,7 @@ blocklist BLOCKLISTS[] = {
     .name = "cybercrime",
     .desc = "A list of IP addresses recommended for block by " \
             "cybercrime-tracker.net",
-    .path = "/usr/local/share/pf/blocklists/cybercrime_tracker.txt",
+    .filename = "malware_cybercrimetracker.txt",
     .table = "malware",
     .url = "https://iplists.firehol.org/files/cybercrime.ipset",
     .format = "ipset"
@@ -85,7 +85,7 @@ blocklist BLOCKLISTS[] = {
     .name = "binarydefense.com",
     .desc = "A list of IP addresses recommended for block by Binary Defense",
     .table = "reputation",
-    .path = "/usr/local/share/pf/blocklists/binarydefense_banlist.txt",
+    .filename = "reputation_binarydefensebanlist.txt",
     .url = "https://www.binarydefense.com/banlist.txt",
     .format = "ipset"
   },
@@ -95,7 +95,7 @@ blocklist BLOCKLISTS[] = {
   [9] = {
     .name = "Tor network nodes",
     .desc = "A list of Tor network nodes provided by emergingthreats.net",
-    .path = "/usr/local/share/pf/blocklists/tor_network_nodes.txt",
+    .filename = "anonymizers_tornetworknodes.txt",
     .table = "anonymizers",
     .url = "https://iplists.firehol.org/files/et_tor.ipset",
     .format = "ipset"
@@ -106,7 +106,7 @@ blocklist BLOCKLISTS[] = {
   [10] = {
     .name = "adservers",
     .desc = "A list of IP addresses associated with adware",
-    .path = "/usr/local/share/pf/blocklists/yoyo_adservers.txt",
+    .filename = "adware_yoyoadservers.txt",
     .table = "adware",
     .url = "https://pgl.yoyo.org/adservers/iplist.php?ipformat=plain&showintro=0&mimetype=plaintext",
     .format = "ipset"

--- a/src/blocklists.c
+++ b/src/blocklists.c
@@ -114,7 +114,7 @@ blocklist BLOCKLISTS[] = {
 };
 
 htable*
-group_blocklists_by_category(blocklist blocklists[], size_t size) {
+group_blocklists(blocklist blocklists[], size_t size) {
   htable *table;
   dyn_array *ary;
   table = safe_malloc(sizeof(htable));

--- a/src/path.c
+++ b/src/path.c
@@ -1,0 +1,78 @@
+#include <blocklist.pf/path.h>
+
+static char* join_sep(char *str, char *chr);
+
+char*
+blocklistpf_dir(void) {
+  if (getenv("BLOCKLISTPF_DIR")) {
+    return strdup(getenv("BLOCKLISTPF_DIR"));
+  } else if (getenv("XDG_DATA_HOME")){
+    return join_path(getenv("XDG_DATA_HOME"), "blocklist.pf", NULL);
+  } else if (getenv("HOME")) {
+    return join_path(getenv("HOME"), ".local", "share", "blocklist.pf", NULL);
+  } else {
+    return strdup("/usr/local/share/blocklist.pf");
+  }
+}
+
+char*
+join_path(char *str, ...) {
+  char *path;
+  int c;
+  va_list args;
+  path = strdup("\0");
+  c = 0;
+  va_start(args, str);
+  while(str != NULL) {
+    char *j;
+    j = join_sep(str, "/");
+    c += strlen(j);
+    path = realloc(path, sizeof(char[c + 2]));
+    strncat(path, j, strlen(j));
+    str = va_arg(args, char*);
+  }
+  va_end(args);
+  return path;
+}
+
+int
+mkdir_p(char *path) {
+  char *token, *copy;
+  struct stat st;
+  path = strdup(path);
+  copy = NULL;
+  while ((token = strsep(&path, "/")) != NULL) {
+    if (strlen(token) == 0) {
+      continue;
+    }
+    copy = (copy ? join_path(copy, token, NULL) : join_path(token, NULL));
+    errno = 0;
+    if (stat(copy, &st) == -1) {
+      if (errno == ENOENT) {
+        errno = 0;
+        return mkdir(copy, S_IRWXU | S_IFDIR);
+      } else {
+        return -1;
+      }
+    }
+  }
+  return 0;
+}
+
+static char*
+join_sep(char *str, char *sep) {
+  int len, i, j;
+  char *cpy, *cpyptr;
+  len = strlen(str);
+  cpyptr = cpy = malloc(sizeof(char[len + 2]));
+  cpyptr = cpy;
+  memcpy(cpyptr++, sep, 1);
+  i = str[0] == *sep ? 1 : 0;
+  j = str[len-1] == *sep ? len-1 : len;
+  while(i < j) {
+    memcpy(cpyptr++, &str[i], 1);
+    i++;
+  }
+  memcpy(cpyptr, "\0", 1);
+  return cpy;
+}


### PR DESCRIPTION
In order of preference, the blocklists that are fetched can be saved to:

* `$BLOCKLISTPF_DIR`
* Otherwise: `$XDG_DATA_HOME/blocklist.pf/`
* Otherwise: `$HOME/.local/share/blocklist.pf`
* Otherwise: `/usr/local/share/blocklist.pf`