### PR TITLE
Move closer to OpenBSD support

### DIFF
--- a/include/blocklist.pf/blocklist.h
+++ b/include/blocklist.pf/blocklist.h
@@ -13,5 +13,7 @@ typedef struct {
 
 
 extern const char* TABLES[5];
+extern int TABLES_LEN;
 extern blocklist BLOCKLISTS[11];
+extern int BLOCKLISTS_LEN;
 dyn_array* group_blocklists(const char*);

--- a/include/blocklist.pf/blocklist.h
+++ b/include/blocklist.pf/blocklist.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <blocklist.pf/hash.h>
 #include <blocklist.pf/dyn_array.h>
 #include <stdlib.h>
 
@@ -15,4 +14,4 @@ typedef struct {
 
 extern const char* TABLES[5];
 extern blocklist BLOCKLISTS[11];
-htable* group_blocklists(blocklist blocklist[], size_t size);
+dyn_array* group_blocklists(const char*);

--- a/include/blocklist.pf/hash.h
+++ b/include/blocklist.pf/hash.h
@@ -1,4 +1,0 @@
-#pragma once
-#include <search.h>
-typedef struct hsearch_data htable;
-typedef ENTRY hitem;

--- a/src/blocklists.c
+++ b/src/blocklists.c
@@ -7,6 +7,8 @@ const char *TABLES[] =
   "anonymizers", "adware"
 };
 
+int TABLES_LEN = sizeof(TABLES) / sizeof(TABLES[0]);
+
 blocklist BLOCKLISTS[] =
 {
   /**
@@ -134,14 +136,14 @@ blocklist BLOCKLISTS[] =
   },
 };
 
+int BLOCKLISTS_LEN = sizeof(BLOCKLISTS) / sizeof(BLOCKLISTS[0]);
+
 dyn_array *
 group_blocklists(const char *tbl)
 {
   dyn_array *bl_grp;
-  int len;
   bl_grp = array_init();
-  len = sizeof(BLOCKLISTS) / sizeof(BLOCKLISTS[0]);
-  for (int i = 0; i < len; i++)
+  for (int i = 0; i < BLOCKLISTS_LEN; i++)
   {
     blocklist *bl;
     bl = &BLOCKLISTS[i];

--- a/src/blocklists.c
+++ b/src/blocklists.c
@@ -134,29 +134,20 @@ blocklist BLOCKLISTS[] =
   },
 };
 
-htable *
-group_blocklists(blocklist blocklists[], size_t size)
+dyn_array *
+group_blocklists(const char *tbl)
 {
-  htable *table;
-  dyn_array *ary;
-  table = safe_malloc(sizeof(htable));
-  hcreate_r(0, table);
-  for (int i = 0; i < (int)(size); i++)
+  dyn_array *bl_grp;
+  int len;
+  bl_grp = array_init();
+  len = sizeof(BLOCKLISTS) / sizeof(BLOCKLISTS[0]);
+  for (int i = 0; i < len; i++)
   {
-    hitem *item, *fitem;
     blocklist *bl;
-    bl = &blocklists[i];
-    item = safe_malloc(sizeof(hitem));
-    item->key = (char *)bl->table;
-    if (hsearch_r(*item, FIND, &fitem, table) == 0) {
-      ary = array_init();
-      array_push(ary, bl);
-      item->data = ary;
-      hsearch_r(*item, ENTER, &fitem, table);
-    } else {
-      array_push(ary, bl);
-      fitem->data = ary;
+    bl = &BLOCKLISTS[i];
+    if (strncmp(bl->table, tbl, strlen(bl->table)) == 0) {
+      array_push(bl_grp, bl);
     }
   }
-  return (table);
+  return (bl_grp);
 }

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -4,6 +4,7 @@
 #include <blocklist.pf/set.h>
 #include <blocklist.pf/dyn_array.h>
 #include <blocklist.pf/path.h>
+#include <blocklist.pf/blocklist.h>
 
 void
 fetch_cmd(void)
@@ -33,7 +34,7 @@ cat_cmd(void)
   char *str, *dir;
   struct Set set = RB_INITIALIZER(&set);
   dir = blocklistpf_dir();
-  for (int i = 0; i < (int)(sizeof(TABLES) / sizeof(TABLES[0])); i++)
+  for (int i = 0; i < TABLES_LEN; i++)
   {
     dyn_array *bls;
     const char *tbl;

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -3,7 +3,6 @@
 #include <blocklist.pf/cmd.h>
 #include <blocklist.pf/set.h>
 #include <blocklist.pf/dyn_array.h>
-#include <blocklist.pf/hash.h>
 #include <blocklist.pf/path.h>
 
 void
@@ -32,25 +31,20 @@ void
 cat_cmd(void)
 {
   char *str, *dir;
-  htable *table;
-  dyn_array *blocklists;
-  hitem item, *fitem;
-  size_t bl_size;
   struct Set set = RB_INITIALIZER(&set);
-  bl_size = sizeof(BLOCKLISTS) / sizeof(BLOCKLISTS[0]);
-  table = group_blocklists(BLOCKLISTS, bl_size);
   dir = blocklistpf_dir();
   for (int i = 0; i < (int)(sizeof(TABLES) / sizeof(TABLES[0])); i++)
   {
-    item.key = (char *)TABLES[i];
-    hsearch_r(item, FIND, &fitem, table);
-    printf("table <%s> {\n", fitem->key);
-    blocklists = fitem->data;
-    for (int j = 0; j < blocklists->size; j++)
+    dyn_array *bls;
+    const char *tbl;
+    tbl = TABLES[i];
+    bls = group_blocklists(tbl);
+    printf("table <%s> {\n", tbl);
+    for (int j = 0; j < bls->size; j++)
     {
       blocklist *bl;
       dyn_array *file;
-      bl = blocklists->items[j];
+      bl = bls->items[j];
       printf("##\n# %s\n# %s\n# %s\n", bl->name, bl->desc, bl->url);
       file = read_file(join_path(dir, bl->filename, NULL));
       file = filter_file(file, &set);


### PR DESCRIPTION
Although OpenBSD supports `search.h`, it does not have the 
same range of functions available as FreeBSD. This change 
reverts to a simpler mechanism for grouping blocklists by 
their table name, and will hopefully bring us one step closer 
to OpenBSD support.