### PR TITLE
Fixes for OpenBSD support

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -44,12 +44,12 @@ cat_cmd(void)
     for (int j = 0; j < bls->size; j++)
     {
       blocklist *bl;
-      dyn_array *file;
+      dyn_array *file, *ipset;
       bl = bls->items[j];
       printf("##\n# %s\n# %s\n# %s\n", bl->name, bl->desc, bl->url);
       file = read_file(join_path(dir, bl->filename, NULL));
-      file = filter_file(file, &set);
-      str = format_file(file, 3);
+      ipset = filter_file(file, &set);
+      str = format_file(ipset, 3);
       printf("%s", str);
       free(str);
     }

--- a/src/file.c
+++ b/src/file.c
@@ -24,13 +24,16 @@ format_file(dyn_array *file, int per_line)
     char *line;
     line = chomp(file->items[i - 1]);
     len += strlen(line);
-    ptr = mempcpy(ptr, line, strlen(line));
+    memcpy(ptr, line, strlen(line));
+    ptr += strlen(line);
     if ((i % per_line == 0) || (i == file->size)) {
-      ptr = mempcpy(ptr, " \\\n", 3);
+      memcpy(ptr, " \\\n", 3);
       len += 3;
+      ptr += 3;
     } else {
-      ptr = mempcpy(ptr, ", ", 2);
+      memcpy(ptr, ", ", 2);
       len += 2;
+      ptr += 2;
     }
   }
   str[len] = '\0';
@@ -41,25 +44,24 @@ format_file(dyn_array *file, int per_line)
 dyn_array *
 filter_file(dyn_array *file, struct Set *set)
 {
+  dyn_array *ipset;
+  ipset = array_init();
   for (int i = 0; i < file->size; i++)
   {
     if ((strncmp(file->items[i], "#", 1) == 0) ||
       is_space(file->items[i])) {
-      array_free_item(file, i);
-      i--;
+      continue;
     } else {
       SetNode *node;
       node = safe_malloc(sizeof(SetNode));
       node->str = strdup(file->items[i]);
       if (RB_FIND(Set, set, node) == NULL) {
         RB_INSERT(Set, set, node);
-      } else {
-        array_free_item(file, i);
-        i--;
+        array_push(ipset, node->str);
       }
     }
   }
-  return (file);
+  return (ipset);
 }
 
 


### PR DESCRIPTION
`mempcpy` is not available on OpenBSD, use pointer arthimetic
 instead. And `filter_file` would segfault - solved by creating a new
 dyn_array for filtered content rather than mutating the same dyn_array.